### PR TITLE
Add compatibility with emonpi and flexible sending of data via MQTT

### DIFF
--- a/emonglcd-send.cfg
+++ b/emonglcd-send.cfg
@@ -1,0 +1,23 @@
+#blindConfigure configuration file
+# connects to mysql database and sends config to blindController nodes via mqtt -> emonpi
+
+#log debug to STDOUT if set to 1
+debug:1 
+
+#mqtt params
+mqtt_hostname: emonpi.pearson.uk:1883
+mqtt_user: emonpi
+mqtt_pass: emonpimqtt2016
+
+#mqtt topics for publishing 
+mqtt_pub_topic: emonhub/tx
+
+#mqtt topics for subscribing to 
+mqtt_sub_solarW:emon/samilpower/PAC
+mqtt_sub_solarKwh:emon/samilpower/ETODAY
+mqtt_sub_utilityW:emon/socomec/Kw
+mqtt_sub_utilityKwh:emon/socomec/Kwhplus
+
+#CSV list of RF IDs of emonglcd displays
+emonglcd_nodeid:20 
+

--- a/emonglcd-send.pl
+++ b/emonglcd-send.pl
@@ -1,0 +1,153 @@
+#!/usr/bin/perl -w
+
+# Send data to emonGLCD wireless power display device
+# Subscribes to MQTT topic from emonhub, listens for updates to
+# the utility power and solar readings, and then sends them via 
+# emonhub/RF to emonGLCD units
+
+use Net::MQTT::Simple;
+use Net::MQTT::Simple::Auth;
+use POSIX  'strftime';
+use Config::Simple;
+
+use File::Basename qw(dirname);
+use Cwd  qw(abs_path);
+use lib dirname(dirname abs_path $0) . '/libs/perl';
+
+use HomeAutomation ;
+
+
+
+
+my $mqtt ; 
+my $nodeId = 0 ;
+my $mqttMsg = "0" ;
+my %mqttData = () ;
+my $utilityW = 0 ;
+my $solarW = 0 ;
+my $utilityKwh = 0 ;
+my $solarKwh = 0 ;
+my $lastSend = 0 ;	#when we last sent to emonglcd
+my $sendInterval = 15 ; #only send max every $sendInterval secs
+
+
+
+my $cfg = new Config::Simple('/etc/emonglcd-send.cfg') ;
+
+
+#MQTT params
+my $mqttTopic = $cfg->param('mqtt_pub_topic') ;
+
+
+my $debug = $cfg->param('debug') ;
+
+
+sub sendToEmonglcd {
+	
+	my ($solarW, $utilityW) = @_ ;
+	my $mqttValues = "0" ;
+
+
+
+	#Send the time
+
+	my $hour = strftime('%H', localtime) ;
+	my $min = strftime('%M', localtime) ;
+	my $sec = strftime('%S', localtime) ;
+
+	$mqttValues= "$hour," . "$min," . "$sec," . "$utilityW," . "$solarW," . "$utilityKwh," . "$solarKwh" ;  
+	
+	if ($debug) {
+		print "sendToemonglcd: Creating MQTT payload for emonglcd : $mqttValues \n";
+	}
+
+	return $mqttValues ;
+
+}
+
+
+
+
+
+sub msgRecv {
+
+	my  ($topic, $msg) = @_ ;
+
+	my $sendNow = 0 ;
+
+	if ($debug) {
+		print "MQTT: topic $topic sent payload ($msg) \n" ;
+	}
+
+
+	if ($topic eq $cfg->param('mqtt_sub_utilityW') ) {
+		$utilityW = $msg * 1000;
+		$sendNow = 1;
+	} elsif ($topic eq $cfg->param('mqtt_sub_utilityKwh') ) {
+		#multiply by 100 so we only send ints
+		$utilityKwh = $msg * 100 ;
+		$sendNow = 0;
+	} elsif ($topic eq $cfg->param('mqtt_sub_solarW') ) {
+		$solarW = $msg ;
+		$sendNow = 1;
+	} elsif ($topic eq $cfg->param('mqtt_sub_solarKwh') ) {
+		#multiply by 100 so we only send ints
+		$solarKwh = $msg * 100 ;
+		$sendNow = 0;
+	}
+
+
+	# build the mqtt payload
+	$mqttData{msg} = sendToEmonglcd($solarW,$utilityW,$solarKwh,$utilityKwh) ;
+
+
+	if ( time() - $sendInterval > $lastSend || $sendNow) {
+		# Set MQTT topic to emonhub/tx/<nodeid>/values  for TX by emonpi
+
+		foreach my $emonglcdNodeId (split (',', $cfg->param('emonglcd_nodeid')) ) {
+			$mqttTopic =  $mqttTopic . "/" . $emonglcdNodeId ."/values" ;
+			HomeAutomation::mqttSend(\$mqtt, $mqttTopic, %mqttData) ;
+			$lastSend = time() ;
+			if ($debug) {
+				print "msgRecv $mqttData{msg} sent to emonglcd node $emonglcdNodeId \n" ;
+			}
+		}
+	}
+	
+
+	return ;
+}
+
+
+
+
+#########################################################################################################################
+# Main															#
+#########################################################################################################################
+
+
+if ($debug) {
+	print "Emonglcd updater started. \n" ;
+	print "Connecting to MQTT broker..\n" ;
+}
+
+# MQTT Connect 
+$mqtt = Net::MQTT::Simple::Auth->new($cfg->param('mqtt_hostname'), $cfg->param('mqtt_user'), $cfg->param('mqtt_pass') );
+
+if ( $mqtt ) {
+	
+	if ($debug) {
+		print ("MQTT connected to broker " . $cfg->param('mqtt_hostname') . "\n") ;
+	}
+	$mqtt->subscribe($cfg->param('mqtt_sub_solarW'), \&msgRecv) ; 
+	$mqtt->subscribe($cfg->param('mqtt_sub_utilityW'), \&msgRecv) ; 
+	$mqtt->subscribe($cfg->param('mqtt_sub_solarKwh'), \&msgRecv) ; 
+	$mqtt->subscribe($cfg->param('mqtt_sub_utilityKwh'), \&msgRecv) ; 
+	$mqtt->run() ;
+} else {
+	print ("MQTT ERROR could not connect to broker " . $cfg->param('mqtt_hostname') . "\n") ;
+}
+
+
+
+exit () ;

--- a/firmware/SolarPV/templates.ino
+++ b/firmware/SolarPV/templates.ino
@@ -4,7 +4,7 @@
 #include "utility/font_clR4x6.h"
 #include "utility/font_clR6x8.h"
 
-/*
+
 //------------------------------------------------------------------
 // Draws a page showing a single power and energy value in big font
 //------------------------------------------------------------------
@@ -16,7 +16,7 @@ void draw_power_page(char* powerstr, double powerval, char* energystr,  double e
   char str[50];    			 //variable to store conversion 
   glcd.setFont(font_clR6x8);      
   strcpy(str,powerstr);  
-  strcat(str," NOW:"); 
+  strcat(str," now:"); 
   glcd.drawString(0,0,str);
   strcpy(str,energystr);  
   strcat(str," TODAY:"); 
@@ -65,13 +65,13 @@ void draw_temperature_time_footer(double temp, double mintemp, double maxtemp, d
   // Time
   char str2[5];
   itoa((int)hour,str,10);
-  if  (minute<10) strcat(str,":0"); else strcat(str,":");
+  if  (minute<10) strcat(str,": 0"); else strcat(str,": ");
   itoa((int)minute,str2,10);
   strcat(str,str2); 
   glcd.setFont(font_helvB12);
   glcd.drawString(88,50,str);
 
-}*/
+}
 
 //------------------------------------------------------------------
 // Draws the Solar import/export page
@@ -98,7 +98,7 @@ void draw_solar_page(double use, double usekwh, double gen, double maxgen, doubl
   char str2[5];
 
   // Last seen information from EmonTX
-  if ((millis()-last_emontx)>20000)
+  if ((millis()-last_emontx)>120000)
   {
     // small font
     glcd.setFont(font_clR4x6);
@@ -112,7 +112,7 @@ void draw_solar_page(double use, double usekwh, double gen, double maxgen, doubl
       glcd.drawString(66,0,PSTR("TxFail"));
     
   }
-  if ((millis()-last_emonbase)>120000)
+  if ((millis()-last_emonbase)>180000)
   {
     // small font
     glcd.setFont(font_clR4x6);

--- a/readme.md
+++ b/readme.md
@@ -27,9 +27,9 @@ The emonGLCD has an on-board temperate sensor, light sensor and two tri-color am
 
 ## Using with emonpi
 
-The latest emonglcd firmware supports reading data that is transmitted via emonpi. 
-Simply edit firmware/SolarPV.ino and ensure line 63 has the nodeId of your emonpi
-A companion script (emonglcd-send.pl) has been provided in this repo that reads any emonhub node/feed values and transmits them to mulitple emonglcd
+The latest emonglcd firmware supports reading data that is transmitted via emonpi.  
+Simply edit firmware/SolarPV.ino and ensure line 63 has the nodeId of your emonpi. 
+A companion script (emonglcd-send.pl) has been provided in this repo that reads any emonhub node/feed values and transmits them to mulitple emonglcd(s). 
 Simply place the emonglcd-send.cfg file in /etc , edit it with your emonGLCD nodeid(s) and the variables you wish to use for solarW, utilityW, solarKwh and utilityKwh.
 The script will update the emonpi each time any of these node variables change in emonhub.
 emonglcd-send.pl works by subscribing to these topics via MQTT and using MQTT to make RF transmit requests to emonhub (which are then sent to each emonglcd).
@@ -38,7 +38,7 @@ A systemd run file has also been provided to run this at startup, simply place s
  
 
 Add the following definition into your emonhub.conf file for each emonGlcd that you have:
-
+```
 [[20]]
     nodename = emonglcd
     firmware =V1_1
@@ -52,6 +52,7 @@ Add the following definition into your emonhub.conf file for each emonGlcd that 
      names =nodeid,hour,minute,second,utilityW,solarW,utilityKwh,solarKwh
      datacodes =b,b,b,h,h,H,H
      units = h,min,sec,W,W,kwh,kwh
+```
 
 ## Using without emonpi (sniff from emonTx)
 To use without emonpi and have the emonglcd sniff the data from a emonTx, simply change line 64 to include your nodeId of the emonTx, and undef EMONPI in line 63:

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 A general purpose wireless graphical LCD display unit. Powered by an Atmega328 with an Arduino bootloader.
 
-The emonGLCD is designed to drive a 128x64 GLCD display based on the ST7565 driver. The board has a built in HopeRF RFM12B wireless module to receive data from the emonTx energy monitoring node or an emonBase (Nanode-RF web-connected basestation) which in turn could be pulled aggregated data from a web-sever to be displayed.
+The emonGLCD is designed to drive a 128x64 GLCD display based on the ST7565 driver. The board has a built in HopeRF RFM12B wireless module to receive data from emonpi or a emonTx energy monitoring node or an emonBase (Nanode-RF web-connected basestation) which in turn could be pulled aggregated data from a web-sever to be displayed.
 
 The emonGLCD has an on-board temperate sensor, light sensor and two tri-color ambient indicator LED's.
 
@@ -20,8 +20,44 @@ The emonGLCD has an on-board temperate sensor, light sensor and two tri-color am
 * DS18B20 on-board temperature sensor
 * On-board LDR light-level sensor
 * Based on JeeLabs.org design. Uses Adafruit/JeeLabs GLCD library
-* Software RTC updated from the internet via emonbase.
+* Software RTC updated from the internet via emonpi.
 
+
+
+
+## Using with emonpi
+
+The latest emonglcd firmware supports reading data that is transmitted via emonpi. 
+Simply edit firmware/SolarPV.ino and ensure line 63 has the nodeId of your emonpi
+A companion script (emonglcd-send.pl) has been provided in this repo that reads any emonhub node/feed values and transmits them to mulitple emonglcd
+Simply place the emonglcd-send.cfg file in /etc , edit it with your emonGLCD nodeid(s) and the variables you wish to use for solarW, utilityW, solarKwh and utilityKwh.
+The script will update the emonpi each time any of these node variables change in emonhub.
+emonglcd-send.pl works by subscribing to these topics via MQTT and using MQTT to make RF transmit requests to emonhub (which are then sent to each emonglcd).
+
+A systemd run file has also been provided to run this at startup, simply place systemd/emonglcd.service into /lib/systemd/system and run 'systemctl enable emonglcd'
+ 
+
+Add the following definition into your emonhub.conf file for each emonGlcd that you have:
+
+[[20]]
+    nodename = emonglcd
+    firmware =V1_1
+    hardware = emonglcd
+    [[[rx]]]
+     names = temperature,
+     datacodes = h
+     scales = 0.01,1
+     units = c
+  [[[tx]]]
+     names =nodeid,hour,minute,second,utilityW,solarW,utilityKwh,solarKwh
+     datacodes =b,b,b,h,h,H,H
+     units = h,min,sec,W,W,kwh,kwh
+
+## Using without emonpi (sniff from emonTx)
+To use without emonpi and have the emonglcd sniff the data from a emonTx, simply change line 64 to include your nodeId of the emonTx, and undef EMONPI in line 63:
+
+#undef EMONPI
+#define EMONTX  27
 
 ## Build Guide
 

--- a/systemd/emonglcd.service
+++ b/systemd/emonglcd.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=EmonGLCD display update service
+After=network.target mosquitto.service
+
+[Service]
+Restart=on-failure
+User=solar
+TimeoutSec=5min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+ExecStart=/home/solar/home_automation/EmonGLCD/emonglcd-send.pl
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This feature adds the ability of emonGLCD to work with emonpi, and for the emonGLCD to receive data via MQTT.

It allows to select any node/input variable in emonpi and send them to multiple emonGLCDs for display using MQTT (script provided to do so)
It also makes minor improvements to the codebase, for example checking RF data received length and if the RF data is for itself. 

The emonGLCD is a great device and I'm saddened to hear it's discontinued. Maybe this code update will make it live again ? 
